### PR TITLE
Use attributes to define the supported authentication contexts for commands

### DIFF
--- a/src/Reddit.NET.Client/Authentication/Context/ClientCredentialsAuthenticationContext.cs
+++ b/src/Reddit.NET.Client/Authentication/Context/ClientCredentialsAuthenticationContext.cs
@@ -9,14 +9,12 @@ namespace Reddit.NET.Client.Authentication.Context
     /// </summary>
     public sealed class ClientCredentialsAuthenticationContext : AuthenticationContext
     {
-        private static readonly string[] s_supportedCommandIds = Constants.Command.ReadOnlyCommandIds;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="ClientCredentialsAuthenticationContext" /> class.
         /// </summary>
         /// <param name="token">The authentication token for this context.</param>
         public ClientCredentialsAuthenticationContext(Token token)
-            : base(s_supportedCommandIds)
+            : base()
         {
             Token = Requires.NotNull(token, nameof(token));
         }

--- a/src/Reddit.NET.Client/Authentication/Context/ReadOnlyAuthenticationContextAttribute.cs
+++ b/src/Reddit.NET.Client/Authentication/Context/ReadOnlyAuthenticationContextAttribute.cs
@@ -1,0 +1,18 @@
+using Reddit.NET.Client.Authentication.Abstract;
+
+namespace Reddit.NET.Client.Authentication.Context
+{
+    /// <summary>
+    /// Used to indicate that a read-only <see cref="AuthenticationContext" /> is supported.
+    /// </summary>
+    public sealed class ReadOnlyAuthenticationContextAttribute : SupportedAuthenticationContextAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ReadOnlyAuthenticationContextAttribute" /> class.
+        /// </summary>
+        public ReadOnlyAuthenticationContextAttribute()
+            : base(typeof(ClientCredentialsAuthenticationContext))
+        {
+        }
+    }
+}

--- a/src/Reddit.NET.Client/Authentication/Context/SupportedAuthenticationContextAttribute.cs
+++ b/src/Reddit.NET.Client/Authentication/Context/SupportedAuthenticationContextAttribute.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Linq;
+using Microsoft;
+using Reddit.NET.Client.Authentication.Abstract;
+using Reddit.NET.Client.Command;
+
+namespace Reddit.NET.Client.Authentication.Context
+{
+    /// <summary>
+    /// Used to indicate the supported <see cref="AuthenticationContext" /> types for a <see cref="ClientCommand" />.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
+    public abstract class SupportedAuthenticationContextAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SupportedAuthenticationContextAttribute" /> class.
+        /// </summary>
+        /// <param name="types">The <see cref="AuthenticationContext" /> types supported.</param>
+        protected SupportedAuthenticationContextAttribute(params Type[] types)
+        {
+            Requires.NotNull(types, nameof(types));
+            Requires.Argument(
+                types.All(t => t.IsSubclassOf(typeof(AuthenticationContext))),
+                nameof(types),
+                "Types must be all be derived from AuthenticationContext.");
+
+            Types = types;
+        }
+
+        /// <summary>
+        /// Gets the supported <see cref="AuthenticationContext" /> types.
+        /// </summary>
+        public Type[] Types { get; }
+    }
+}

--- a/src/Reddit.NET.Client/Authentication/Context/UserAuthenticationContextAttribute.cs
+++ b/src/Reddit.NET.Client/Authentication/Context/UserAuthenticationContextAttribute.cs
@@ -1,0 +1,18 @@
+using Reddit.NET.Client.Authentication.Abstract;
+
+namespace Reddit.NET.Client.Authentication.Context
+{
+    /// <summary>
+    /// Used to indicate that a user-based <see cref="AuthenticationContext" /> is supported.
+    /// </summary>
+    public sealed class UserAuthenticationContextAttribute : SupportedAuthenticationContextAttribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="UserAuthenticationContextAttribute" /> class.
+        /// </summary>
+        public UserAuthenticationContextAttribute()
+            : base(typeof(UsernamePasswordAuthenticationContext), typeof(UserTokenAuthenticationContext))
+        {
+        }
+    }
+}

--- a/src/Reddit.NET.Client/Authentication/Context/UserTokenAuthenticationContext.cs
+++ b/src/Reddit.NET.Client/Authentication/Context/UserTokenAuthenticationContext.cs
@@ -9,14 +9,12 @@ namespace Reddit.NET.Client.Authentication.Context
     /// </summary>
     public sealed class UserTokenAuthenticationContext : AuthenticationContext
     {
-        private static readonly string[] s_supportedCommandIds = Constants.Command.UserCommandIds;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UserTokenAuthenticationContext" /> class.
         /// </summary>
         /// <param name="token">The authentication token for this context.</param>
         public UserTokenAuthenticationContext(Token token)
-            : base(s_supportedCommandIds)
+            : base()
         {
             Token = Requires.NotNull(token, nameof(token));
         }

--- a/src/Reddit.NET.Client/Authentication/Context/UsernamePasswordAuthenticationContext.cs
+++ b/src/Reddit.NET.Client/Authentication/Context/UsernamePasswordAuthenticationContext.cs
@@ -9,14 +9,12 @@ namespace Reddit.NET.Client.Authentication.Context
     /// </summary>
     public sealed class UsernamePasswordAuthenticationContext : AuthenticationContext
     {
-        private static readonly string[] s_supportedCommandIds = Constants.Command.UserCommandIds;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="UsernamePasswordAuthenticationContext" /> class.
         /// </summary>
         /// <param name="token">The authentication token for this context.</param>
         public UsernamePasswordAuthenticationContext(Token token)
-            : base(s_supportedCommandIds)
+            : base()
         {
             Token = Requires.NotNull(token, nameof(token));
         }

--- a/src/Reddit.NET.Client/Command/Multireddits/AddSubredditToMultiredditCommand.cs
+++ b/src/Reddit.NET.Client/Command/Multireddits/AddSubredditToMultiredditCommand.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Multireddits
 {
     /// <summary>
     /// Defines a command to add a subreddit to a multireddit of the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class AddSubredditToMultiredditCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Multireddits/DeleteMultiredditCommand.cs
+++ b/src/Reddit.NET.Client/Command/Multireddits/DeleteMultiredditCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Multireddits
 {
     /// <summary>
     /// Defines a command to delete a multireddit belonging to the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class DeleteMultiredditCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Multireddits/GetMultiredditDetailsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Multireddits/GetMultiredditDetailsCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Multireddits
 {
     /// <summary>
     /// Defines a command to get the details of a multireddit belonging to the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMultiredditDetailsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Multireddits/GetMultiredditSubmissionsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Multireddits/GetMultiredditSubmissionsCommand.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to get the submissions of a multireddit.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMultiredditSubmissionsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Multireddits/RemoveSubredditFromMultiredditCommand.cs
+++ b/src/Reddit.NET.Client/Command/Multireddits/RemoveSubredditFromMultiredditCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Multireddits
 {
     /// <summary>
     /// Defines a command to remove a subreddit from a multireddit of the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class RemoveSubredditFromMultiredditCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Submissions/GetSubmissionDetailsWithCommentsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Submissions/GetSubmissionDetailsWithCommentsCommand.cs
@@ -3,15 +3,15 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Submissions
 {
     /// <summary>
     /// Defines a command to get the details of a submission and its comments.
     /// </summary>
-    /// <remarks>
-    ///
-    /// </remarks>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class GetSubmissionDetailsWithCommentsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Subreddits/CreateSubredditSubmissionCommand.cs
+++ b/src/Reddit.NET.Client/Command/Subreddits/CreateSubredditSubmissionCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to create a submission in a particular subreddit.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class CreateSubredditSubmissionCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Subreddits/GetFrontPageSubmissionsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Subreddits/GetFrontPageSubmissionsCommand.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to get the submissions on the front page.
     /// </summary>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class GetFrontPageSubmissionsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Subreddits/GetSubredditDetailsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Subreddits/GetSubredditDetailsCommand.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to get the details of a subreddit.
     /// </summary>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class GetSubredditDetailsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Subreddits/GetSubredditSubmissionsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Subreddits/GetSubredditSubmissionsCommand.cs
@@ -3,12 +3,15 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to get the submissions of a subreddit.
     /// </summary>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class GetSubredditSubmissionsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Subreddits/SearchSubredditSubmissionsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Subreddits/SearchSubredditSubmissionsCommand.cs
@@ -4,12 +4,15 @@ using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Web;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to search the submissions of a subreddit.
     /// </summary>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class SearchSubredditSubmissionsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Subreddits/UpdateSubredditSubscriptionCommand.cs
+++ b/src/Reddit.NET.Client/Command/Subreddits/UpdateSubredditSubscriptionCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Subreddits
 {
     /// <summary>
     /// Defines a command to update the subscription to a particular subreddit.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class UpdateSubredditSubscriptionCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/UserContent/ApplyVoteCommand.cs
+++ b/src/Reddit.NET.Client/Command/UserContent/ApplyVoteCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 using Reddit.NET.Client.Models.Public.Read;
 
 namespace Reddit.NET.Client.Command.UserContent
@@ -9,6 +10,7 @@ namespace Reddit.NET.Client.Command.UserContent
     /// <summary>
     /// Defines a command to apply a vote to a submission or comment.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class ApplyVoteCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/UserContent/CreateCommentCommand.cs
+++ b/src/Reddit.NET.Client/Command/UserContent/CreateCommentCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.UserContent
 {
     /// <summary>
     /// Defines a command to create a comment on a submission or as a reply to another comment.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class CreateCommentCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/UserContent/DeleteContentCommand.cs
+++ b/src/Reddit.NET.Client/Command/UserContent/DeleteContentCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.UserContent
 {
     /// <summary>
     /// Defines a command to delete a submission or comment.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class DeleteContentCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/UserContent/SaveOrUnsaveContentCommand.cs
+++ b/src/Reddit.NET.Client/Command/UserContent/SaveOrUnsaveContentCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.UserContent
 {
     /// <summary>
     /// Defines a command to save or unsave a submission or comment.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class SaveOrUnsaveContentCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/CreateMultiredditCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/CreateMultiredditCommand.cs
@@ -4,12 +4,14 @@ using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to create a multireddit belonging to the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class CreateMultiredditCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/GetMyDetailsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetMyDetailsCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the details of the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMyDetailsCommand : ClientCommand
     {
         /// <summary>

--- a/src/Reddit.NET.Client/Command/Users/GetMyInboxMessagesCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetMyInboxMessagesCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the messages in the currently authenticated user's inbox.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMyInboxMessagesCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/GetMyKarmaBreakdown.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetMyKarmaBreakdown.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get a breakdown of karma earned for the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMyKarmaBreakdownCommand : ClientCommand
     {
         /// <summary>

--- a/src/Reddit.NET.Client/Command/Users/GetMyMultiredditsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetMyMultiredditsCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the multireddits of the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMyMultiredditsCommand : ClientCommand
     {
         /// <summary>

--- a/src/Reddit.NET.Client/Command/Users/GetMySubredditsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetMySubredditsCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the subreddits of the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMySubredditsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/GetMyTrophiesCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetMyTrophiesCommand.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the trophies of the currently authenticated user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetMyTrophiesCommand : ClientCommand
     {
         /// <summary>

--- a/src/Reddit.NET.Client/Command/Users/GetUserDetailsCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetUserDetailsCommand.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the details of a specific user.
     /// </summary>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class GetUserDetailsCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/GetUserHistoryCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetUserHistoryCommand.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get history of a user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class GetUserHistoryCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/GetUserTrophiesCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/GetUserTrophiesCommand.cs
@@ -1,11 +1,14 @@
 using System;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to get the trophies of a specific user.
     /// </summary>
+    [ReadOnlyAuthenticationContext]
+    [UserAuthenticationContext]
     public sealed class GetUserTrophiesCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/ReplyToMessageCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/ReplyToMessageCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.UserContent
 {
     /// <summary>
     /// Defines a command to reply to an inbox message.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class ReplyToMessageCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Command/Users/SendMessageCommand.cs
+++ b/src/Reddit.NET.Client/Command/Users/SendMessageCommand.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using Reddit.NET.Client.Authentication.Context;
 
 namespace Reddit.NET.Client.Command.Users
 {
     /// <summary>
     /// Defines a command to send a message to another reddit user.
     /// </summary>
+    [UserAuthenticationContext]
     public sealed class SendMessageCommand : ClientCommand
     {
         private readonly Parameters _parameters;

--- a/src/Reddit.NET.Client/Constants.cs
+++ b/src/Reddit.NET.Client/Constants.cs
@@ -14,64 +14,9 @@ namespace Reddit.NET.Client
     internal static class Constants
     {
         /// <summary>
-        /// The version of the client.
-        /// </summary>
-        public const string Version = "0.1.0";
-
-        /// <summary>
         /// The named used for <see cref="HttpClient" /> instances.
         /// </summary>
         public static string HttpClientName = $"Reddit.NET.Client";
-
-        /// <summary>
-        /// Constants used in commands.
-        /// </summary>
-        public static class Command
-        {
-            /// <summary>
-            /// The supported commands when using a read-only authentication mode.
-            /// </summary>
-            public static string[] ReadOnlyCommandIds = new string[]
-            {
-                nameof(GetSubredditDetailsCommand),
-                nameof(GetSubredditSubmissionsCommand),
-                nameof(SearchSubredditSubmissionsCommand),
-                nameof(GetFrontPageSubmissionsCommand),
-                nameof(GetSubmissionDetailsWithCommentsCommand),
-                nameof(GetUserDetailsCommand),
-                nameof(GetUserTrophiesCommand)
-            };
-
-            /// <summary>
-            /// The supported commands when using a user authentication mode.
-            /// </summary>
-            public static string[] UserCommandIds = ReadOnlyCommandIds
-                .Union(new string[]
-                {
-                    nameof(UpdateSubredditSubscriptionCommand),
-                    nameof(CreateSubredditSubmissionCommand),
-                    nameof(AddSubredditToMultiredditCommand),
-                    nameof(RemoveSubredditFromMultiredditCommand),
-                    nameof(GetMultiredditDetailsCommand),
-                    nameof(GetMultiredditSubmissionsCommand),
-                    nameof(DeleteMultiredditCommand),
-                    nameof(GetMyDetailsCommand),
-                    nameof(GetMySubredditsCommand),
-                    nameof(GetMyKarmaBreakdownCommand),
-                    nameof(GetMyTrophiesCommand),
-                    nameof(GetMyMultiredditsCommand),
-                    nameof(CreateMultiredditCommand),
-                    nameof(GetMyInboxMessagesCommand),
-                    nameof(SendMessageCommand),
-                    nameof(ReplyToMessageCommand),
-                    nameof(GetUserHistoryCommand),
-                    nameof(ApplyVoteCommand),
-                    nameof(SaveOrUnsaveContentCommand),
-                    nameof(DeleteContentCommand),
-                    nameof(CreateCommentCommand)
-                })
-                .ToArray();
-        }
 
         /// <summary>
         /// Constants used to determine reddit 'thing' kinds.

--- a/tests/Reddit.NET.Client.UnitTests/AuthenticationContextTests.cs
+++ b/tests/Reddit.NET.Client.UnitTests/AuthenticationContextTests.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Net.Http;
+using NUnit.Framework;
+using Reddit.NET.Client.Authentication.Context;
+using Reddit.NET.Client.Command;
+using Reddit.NET.Client.Models.Internal;
+
+namespace Reddit.NET.Client.UnitTests
+{
+    public class AuthenticationContextTests
+    {
+        [Test]
+        public void CanExecute_NoAttributeCommand_ThrowsArgumentException()
+        {
+            var authenticationContext = new ClientCredentialsAuthenticationContext(new Token());
+
+            Assert.Throws<ArgumentException>(() => authenticationContext.CanExecute(new NoAttributeCommand()));
+        }
+
+        [Test]
+        public void CanExecute_SingleAttributeCommandReadOnlyAuthenticationContext_ReturnsTrue()
+        {
+            var authenticationContext = new ClientCredentialsAuthenticationContext(new Token());
+
+            Assert.AreEqual(true, authenticationContext.CanExecute(new SingleAttributeCommand()));
+        }
+
+        [Test]
+        public void CanExecute_SingleAttributeCommandUserBasedAuthenticationContext_ReturnsFalse()
+        {
+            var authenticationContext = new UsernamePasswordAuthenticationContext(new Token());
+
+            Assert.AreEqual(false, authenticationContext.CanExecute(new SingleAttributeCommand()));
+        }
+
+        [Test]
+        public void CanExecute_MultipleAttributeCommandReadOnlyAuthenticationContext_ReturnsTrue()
+        {
+            var authenticationContext = new ClientCredentialsAuthenticationContext(new Token());
+
+            Assert.AreEqual(true, authenticationContext.CanExecute(new MultipleAttributeCommand()));
+        }
+
+        [Test]
+        public void CanExecute_MultipleAttributeCommandUserBasedAuthenticationContext_ReturnsTrue()
+        {
+            var authenticationContext = new UsernamePasswordAuthenticationContext(new Token());
+
+            Assert.AreEqual(true, authenticationContext.CanExecute(new MultipleAttributeCommand()));
+        }
+
+        private class NoAttributeCommand : ClientCommand
+        {
+            public override string Id => nameof(NoAttributeCommand);
+
+            public override HttpRequestMessage BuildRequest() =>
+                throw new System.NotImplementedException();
+        }
+
+        [ReadOnlyAuthenticationContext]
+        private class SingleAttributeCommand : ClientCommand
+        {
+            public override string Id => nameof(SingleAttributeCommand);
+
+            public override HttpRequestMessage BuildRequest() =>
+                throw new System.NotImplementedException();
+        }
+
+        [ReadOnlyAuthenticationContext]
+        [UserAuthenticationContext]
+        private class MultipleAttributeCommand : ClientCommand
+        {
+            public override string Id => nameof(MultipleAttributeCommand);
+
+            public override HttpRequestMessage BuildRequest() =>
+                throw new System.NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
The current mechanism of maintaining an array of command identifiers is a bit frustrating, as the list needs to be updated each time a new command is added and the relationship is not necessarily clear. 

The result is a `CommandNotSupportedException` which does not make it clear why it isn't supported (i.e. is it because of a missing identifier or because it's really not supported).

Using attributes will give the following benefits:

- It is clear from looking at a command which authentication context(s) it supports
- If an attribute is not defined for the command, a specific error can be given rather than treating as not supported
- There is no list of command identifiers to maintain

An example of the usage follows:

```cs
// Supports both read-only and user-based authentication contexts
[ReadOnlyAuthenticationContext]
[UserAuthenticationContext]
public class ReadOnlyAndUserExampleCommand : ClientCommand
{
    ...
}

// Supports user-based authentication contexts only
[UserAuthenticationContext]
public class UserExampleCommand : ClientCommand
{
    ...
}
```